### PR TITLE
Allow state to be persisted in URL for standalone profiler

### DIFF
--- a/packages/standalone/src/routes/+page.svelte
+++ b/packages/standalone/src/routes/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import './styles.css';
     //@ts-ignore
-    import { onMount } from 'svelte';
+    import { onMount, tick } from 'svelte';
     //@ts-ignore
-    import { coordinator, wasmConnector } from '@uwdata/mosaic-core';
+    import { coordinator, wasmConnector, clauseInterval } from '@uwdata/mosaic-core';
     //@ts-ignore
     import * as vg from '@uwdata/vgplot';
     //@ts-ignore
@@ -21,14 +21,33 @@
     var dbId = 't_' + uuidv4().replace(/-/g, '');
 
 	let brush: any;
-	
+    let url = '';
+    let generatedURL = '';
+    let stateString = '';
+
     async function initializeDatabase() {
         connector = wasmConnector();        
         db = await connector.getDuckDB();
         coordinator().databaseConnector(connector);
     }
 
+    async function handleURL(){
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Error fetching CSV: ${response.statusText}`);
+        }
+        const csvText = await response.text();
+        db.registerFileText("temp", csvText);
+        await coordinator().exec([
+            vg.loadCSV(dbId, "temp", { replace: true })
+        ]);
+        console.log("temp loaded");
+        await getInfo();
+        
+    }
+
 	async function handleFileInput(event: { target: { files: any[]; }; }) {
+        url = '';
         const file = event.target.files[0];
         if (file) {
 			if (file.type === 'text/csv') {
@@ -77,22 +96,80 @@
             WHERE table_name = '${dbId}'
         `, { cache: false });
 
+        brush = vg.Selection.crossfilter();
         //@ts-ignore
         columnNames = Array.from(col).map(row => row.column_name);
         //@ts-ignore
         columnTypes = Array.from(type).map(row => row.data_type);
 
 		key += 1;
-		brush = vg.Selection.crossfilter();
+
+        await tick()
+        updateDisplay(stateString);
     }
 
-    onMount(async () => {
-        await initializeDatabase();
+    async function updateDisplay(stateString : string) {
+        const clients = coordinator().clients;
+
+        const decodedString = decodeURIComponent(stateString);
+        const state = JSON.parse(decodedString);
+
+        if(typeof state.brushVal[0] != 'number'){
+            state.brushVal = state.brushVal.map((val: string) => new Date(val));
+        }
+        clients.forEach((client: any) => {
+            brush.update(
+                clauseInterval(state.brushField, state.brushVal, { source: client })
+            );
+        });
+    }
+
+    function saveAsURL() {
+        let brushField = brush.active.predicate._deps[0];
+        let brushVal = brush.value;
+        console.log(brushVal);
         
-        const element = document.getElementById('csvFileInput');
-        if (element) {
+        const state = {
+            brushField,
+            brushVal,
+        };
+
+        const jsonString = JSON.stringify(state);
+        const encodedJson = encodeURIComponent(jsonString);
+
+        generatedURL = `${window.location.origin}${window.location.pathname}#url=${url}#state=${encodedJson}`;
+    }
+
+    onMount(async () => {        
+        await initializeDatabase();
+
+        const fullURL = window.location.href;
+        if (fullURL.includes('#url') && fullURL.includes('#state')) {
+            const hashString = window.location.hash.substring(1); 
+            const hashParts = hashString.split('#'); 
+
+            hashParts.forEach(part => {
+                if (part.startsWith('url=')) {
+                    url = decodeURIComponent(part.substring(4)); 
+                } else if (part.startsWith('state=')) {
+                    stateString = decodeURIComponent(part.substring(6)); 
+                }
+            });
+
+            if(url.length > 0){
+                await handleURL();
+            }
+        }
+        
+        const fileInputElement = document.getElementById('csvFileInput');
+        if (fileInputElement) {
             //@ts-ignore
-            element.addEventListener('input', handleFileInput);
+            fileInputElement.addEventListener('input', handleFileInput);
+        }
+        const urlInputElement = document.getElementById('url-input');
+        if (urlInputElement) {
+            //@ts-ignore
+            urlInputElement.addEventListener('input', handleURL);
         }
     });
 </script>
@@ -104,12 +181,32 @@
             <img class="VPImage light" src="mosaic.svg" alt="Mosaic">
         </a>
     </div>
-    <div class="file-input-wrapper">
-        <label class="file-input-label">
-            <input type="file" id="csvFileInput" accept=".csv,.parquet"/>
-            <span>Upload a file</span>
-        </label>
+
+    <div class="input-container">
+        <div class="file-input-wrapper">
+            <label class="file-input-label">
+                <input type="file" id="csvFileInput" accept=".csv,.parquet"/>
+                <span>Upload a file</span>
+            </label>
+        </div>
+        <span class="or-text">or</span>
+        <div class="url-input-container">
+            <input type="text" class="urlinput" id="url-input" placeholder="Enter URL here" bind:value={url} />
+        </div>
     </div>
+
+    <div class="button-container">
+        <button on:click={saveAsURL}>Save as URL</button>
+    </div>
+
+    {#if generatedURL}
+        <div class="url-output">
+            <button class="close-button" on:click={() => generatedURL = ''}>×</button>
+            <p>Copy this URL:</p>
+            <textarea readonly>{generatedURL}</textarea>
+            <button class="copy-button" on:click={() => navigator.clipboard.writeText(generatedURL)}>Copy to clipboard</button>
+        </div>
+    {/if}
 
     {#key key}
     {#if columnNames.length > 0 && brush}

--- a/packages/standalone/src/routes/ColumnProfile.svelte
+++ b/packages/standalone/src/routes/ColumnProfile.svelte
@@ -16,6 +16,16 @@
     export let dbId: string;
     var uniqueId = `plot-${uuidv4()}`;
 
+    function formatXAxisTick(value: number) {
+        if (value >= 1e9) {
+            return (value / 1e9).toFixed(1) + 'B'; 
+        } else if (value >= 1e6) {
+            return (value / 1e6).toFixed(1) + 'M'; 
+        } else {
+            return value; 
+        }
+    }
+
     async function getPlot() {
         if (type == 'DOUBLE' || type == 'BIGINT' || type == 'TINYINT') {
             const data = await coordinator().query(`
@@ -41,7 +51,8 @@
                         vg.xDomain(vg.Fixed),
                         vg.yTickFormat("s"),
                         vg.width(500),
-                        vg.height(200)
+                        vg.height(200),
+                        vg.xTickFormat(formatXAxisTick) 
                     )));
                 } else {
                     element.replaceChildren(vg.vconcat(vg.plot(
@@ -53,7 +64,8 @@
                         vg.xDomain(vg.Fixed),
                         vg.yTickFormat("s"),
                         vg.width(500),
-                        vg.height(200)
+                        vg.height(200),
+                        vg.xTickFormat(formatXAxisTick) 
                     )));
                 }
             }
@@ -100,11 +112,11 @@
             if (element) {
                 element.replaceChildren(vg.vconcat(vg.plot(
                     vg.barY(
-                        vg.from(dbId),
+                        vg.from(dbId, { filterBy: brush }),
                         { x: colName, y: vg.count(), fill: "steelblue", inset: 0.5, sort: {x: "-y", limit: 2}}
                     ),
                     vg.width(500),
-                    vg.height(200),
+                    vg.height(200)
                 )));
             }
         }

--- a/packages/standalone/src/routes/styles.css
+++ b/packages/standalone/src/routes/styles.css
@@ -36,10 +36,14 @@ div, p, input {
         display: none;
     }
 }
+.input-container {
+    display: flex;
+    align-items: center;
+    gap: 10px; /* Space between elements */
+    margin-bottom: 10px; /* Decrease space between first line and second line */
+}
 .file-input-wrapper {
-    margin: 20px 0;
     position: relative;
-    display: inline-block;
 }
 .file-input-label {
     display: flex;
@@ -66,4 +70,102 @@ div, p, input {
     height: 100%;
     opacity: 0;
     cursor: pointer;
+}
+.or-text {
+    font-size: 16px; 
+    color: #333;
+}
+.url-input-container {
+    display: flex;
+    width: 400px;
+    flex-direction: column;
+    gap: 5px; /* Space between input and button */
+}
+.urlinput {
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    outline: none;
+    color: #333;
+    background-color: #f0f0f0;
+}
+.button-container {
+    display: flex;
+    gap: 10px; 
+    margin-top: 5px; 
+    margin-bottom: 10px;
+}
+.button-container button {
+    padding: 10px 20px;
+    font-size: 12px;
+    background-color: #f0f0f0;
+    border: 0px;
+    border-radius: 8px; 
+    cursor: pointer; 
+    text-align: center;
+    color: #333; 
+    font-weight: bold;
+    transition: background-color 0.3s, border-color 0.3s;
+    outline: none;
+}
+.button-container button:hover {
+    background-color: #e0e0e0; 
+}
+.url-output {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-left: 15px;
+    padding-right: 15px;
+    padding-bottom: 15px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    background-color: #f9f9f9;
+    margin-bottom: 15px;
+    position: relative;
+}
+.url-output p {
+    margin-bottom: 10px;
+    font-size: 14px;
+}
+.url-output textarea {
+    width: 100%;
+    max-width: 500px;
+    height: 30px;
+    margin-bottom: 10px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 11px;
+    background-color: #fff;
+    box-sizing: border-box;
+}
+.close-button {
+    position: absolute;
+    top: 10px;
+    left: 10px; 
+    background: none;
+    border: none;
+    font-size: 16px;
+    cursor: pointer;
+    color: #333;
+    transition: color 0.3s, border 0.3s;
+}
+.close-button:hover {
+    color: #007bff;
+    border: none; 
+}
+.copy-button {
+    padding: 10px 20px;
+    font-size: 12px;
+    background-color: #6299e7;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+.copy-button:hover {
+    background-color: #2359a4;
 }


### PR DESCRIPTION
Added feature that loads CSV from a publicly accessible .csv link.
Allows insights to be saved into a URL and shared.
Displays filtered insight from shared URL.
- If data was loaded from a .csv link, the insight URL will include that link as well
- Otherwise, if data was loaded from uploading a file, the insight will be displayed once the user uploads the file